### PR TITLE
Solved alphanumeric bug

### DIFF
--- a/Source/DelphiZXIngQRCode.pas
+++ b/Source/DelphiZXIngQRCode.pas
@@ -1048,7 +1048,7 @@ begin
     end else
     if (Mode = qmAlphanumeric) then
     begin
-      CanAdd := GetAlphanumericCode(Ord(Content[X])) > 0;
+      CanAdd := GetAlphanumericCode(Ord(Content[X])) > -1;
     end else
     if (Mode = qmByte) then
     begin


### PR DESCRIPTION
When the number "0" is the content and the mode used is "qmAlphanumeric" the number "0" is ignored and it is not used by the generated QRCode. This is a bug, since in order alphanumeric "0" number should be supported. 

This pull request solve this bug.
