### PR TITLE
Add ability to set error correction level

### DIFF
--- a/Source/DelphiZXIngQRCode.pas
+++ b/Source/DelphiZXIngQRCode.pas
@@ -33,15 +33,18 @@ type
     FEncoding: TQRCodeEncoding;
     FQuietZone: Integer;
     FElements: T2DBooleanArray;
+    FErrorCorrectionLevel: integer;
     procedure SetEncoding(NewEncoding: TQRCodeEncoding);
     procedure SetData(const NewData: WideString);
     procedure SetQuietZone(NewQuietZone: Integer);
+    procedure SetErrorCorrectionLevel(value: integer);
     function GetIsBlack(Row, Column: Integer): Boolean;
     procedure Update;
   public
     constructor Create;
     property Data: WideString read FData write SetData;
     property Encoding: TQRCodeEncoding read FEncoding write SetEncoding;
+    property ErrorCorrectionLevel: integer read fErrorCorrectionLevel write SetErrorCorrectionLevel;
     property QuietZone: Integer read FQuietZone write SetQuietZone;
     property Rows: Integer read FRows;
     property Columns: Integer read FColumns;
@@ -51,7 +54,7 @@ type
 implementation
 
 uses
-  contnrs, Math, Classes;
+  contnrs, Math, Classes, System.SysUtils;
 
 type
   TByteArray = array of Byte;
@@ -192,11 +195,12 @@ const
 type
   TErrorCorrectionLevel = class
   private
-    FBits: Integer;
+    fOrdinal: Integer;
+    function GetBits:Integer;
   public
+    constructor Create(ordinalValue: Integer); reintroduce;
     procedure Assign(Source: TErrorCorrectionLevel);
-    function Ordinal: Integer;
-    property Bits: Integer read FBits;
+    property Bits: Integer read GetBits;
   end;
 
   TECB = class
@@ -803,7 +807,7 @@ begin
   begin
     FECLevel.Free;
   end;
-  FECLevel := TErrorCorrectionLevel.Create;
+  FECLevel := TErrorCorrectionLevel.Create(0);
   FECLevel.Assign(NewECLevel);
 end;
 
@@ -2320,12 +2324,31 @@ end;
 
 procedure TErrorCorrectionLevel.Assign(Source: TErrorCorrectionLevel);
 begin
-  Self.FBits := Source.FBits;
+  Self.fOrdinal := Source.fOrdinal;
 end;
 
-function TErrorCorrectionLevel.Ordinal: Integer;
+constructor TErrorCorrectionLevel.Create(ordinalValue: Integer);
 begin
-  Result := 0;
+  fOrdinal:=0;
+  if (ordinalValue >= 0) and (ordinalValue <=3) then
+    fOrdinal:=ordinalValue;
+end;
+
+function TErrorCorrectionLevel.GetBits: Integer;
+begin
+  if fOrdinal = 0 then  // level L
+    result:=1
+  else
+  if fOrdinal = 1 then  // level M
+    result:=0
+  else
+  if fOrdinal = 2 then  // level Q
+    result:=3
+  else
+  if fOrdinal = 3 then  // level H
+    result:=2
+  else
+    result:=1;
 end;
 
 { TVersion }
@@ -2417,7 +2440,7 @@ end;
 
 function TVersion.GetECBlocksForLevel(ECLevel: TErrorCorrectionLevel): TECBlocks;
 begin
-  Result := ECBlocks[ECLevel.Ordinal];
+  Result := ECBlocks[ECLevel.fOrdinal];
 end;
 
 function TVersion.GetTotalCodewords: Integer;
@@ -3479,7 +3502,7 @@ begin
   end;
 end;
 
-function GenerateQRCode(const Input: WideString; EncodeOptions: Integer): T2DBooleanArray;
+function GenerateQRCode(const Input: WideString; EncodeOptions: Integer; AErrorCorrectionLevel:Integer): T2DBooleanArray;
 var
   Encoder: TEncoder;
   Level: TErrorCorrectionLevel;
@@ -3487,8 +3510,7 @@ var
   X: Integer;
   Y: Integer;
 begin
-  Level := TErrorCorrectionLevel.Create;
-  Level.FBits := 1;
+  Level := TErrorCorrectionLevel.Create(AErrorCorrectionLevel);
   Encoder := TEncoder.Create;
   QRCode := TQRCode.Create;
   try
@@ -3554,6 +3576,18 @@ begin
   end;
 end;
 
+procedure TDelphiZXingQRCode.SetErrorCorrectionLevel(value: integer);
+begin
+  if (value < 0) or (value > 3) then
+    raise Exception.Create('invalid error correction value. must be in range 0..3.');
+
+  if value <> fErrorCorrectionLevel then
+  begin
+    FErrorCorrectionLevel:=value;
+    Update;
+  end;
+end;
+
 procedure TDelphiZXingQRCode.SetQuietZone(NewQuietZone: Integer);
 begin
   if ((FQuietZone <> NewQuietZone) and (NewQuietZone >= 0) and (NewQuietZone <= 100)) then
@@ -3565,7 +3599,7 @@ end;
 
 procedure TDelphiZXingQRCode.Update;
 begin
-  FElements := GenerateQRCode(FData, Ord(FEncoding));
+  FElements := GenerateQRCode(FData, Ord(FEncoding), FErrorCorrectionLevel);
   FRows := Length(FElements) + FQuietZone * 2;
   FColumns := FRows;
 end;


### PR DESCRIPTION
The change was made by "mat" on [StackOverflow](https://stackoverflow.com/questions/44160153/qr-codes-encoded-by-delphizxingqrcode-not-decodable-with-errorcorrectionlevel)
